### PR TITLE
fix: remove test-release branch used for testing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,6 @@ env:
 on:
   push:
     branches:
-      - test-release/*
       - release/*
 
 jobs:


### PR DESCRIPTION
The `test-release` branch was used for initial testing of the workflow