### PR TITLE
Feature/testnet fixes and improvements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,13 @@ import { AuditList } from './layout/AuditList'
 import { Balances } from './layout/Balances'
 import { GnosisSafeProvider } from './contexts'
 
+let bg_color = "#004e80" // mainnet background color is a shade of blue
+if (typeof MC_NETWORK  !== 'undefined') {
+  if (MC_NETWORK == 'testnet') {
+    bg_color = "#774e80" // testnet background color is lavender
+  }
+}
+
 export const App = () => {
   const theme = createTheme({
     palette: {
@@ -35,7 +42,7 @@ export const App = () => {
             height: '100vh',
             display: 'flex',
             flexDirection: 'column',
-            backgroundColor: '#004e80',
+            backgroundColor: `${bg_color}`
           }}
         >
           <Header />

--- a/frontend/src/layout/AuditList.tsx
+++ b/frontend/src/layout/AuditList.tsx
@@ -88,7 +88,7 @@ export const AuditList: FC = (): ReactElement => {
               dataLength={mints.length}
               next={fetchMints}
               hasMore={true}
-              loader={<h4>Loading...</h4>}
+              // loader={<h4>Loading...</h4>}
               scrollableTarget="scrollableMints"
             >
               {mints.map((i, index) => (
@@ -110,17 +110,22 @@ export const AuditList: FC = (): ReactElement => {
               boxShadow: 'rgba(0, 0, 0, 1) 0px 5px 15px',
             }}
           >
-            <InfiniteScroll
-              dataLength={burns.length}
-              next={fetchBurns}
-              hasMore={true}
-              loader={<h4>Loading...</h4>}
-              scrollableTarget="scrollableBurns"
-            >
-              {burns.map((i, index) => (
-                <AuditedBurn auditedBurn={i} key={index} />
-              ))}
-            </InfiniteScroll>
+            {burns.length > 0 && 
+              <InfiniteScroll
+                dataLength={burns.length}
+                next={fetchBurns}
+                hasMore={true}
+                scrollableTarget="scrollableBurns"
+              >
+                {burns.map((i, index) => (
+                  <AuditedBurn auditedBurn={i} key={index} />
+                ))}
+
+              </InfiniteScroll>
+            }
+            {burns.length == 0 &&
+              <h4>&nbsp;&nbsp;None</h4>
+            }
           </div>
         </Grid>
       </Grid>

--- a/frontend/src/layout/Header.tsx
+++ b/frontend/src/layout/Header.tsx
@@ -2,6 +2,13 @@ import React, { FC, ReactElement } from 'react'
 import { Box, Container, Toolbar, Typography } from '@mui/material'
 import { eUSDIcon } from '../components/icons'
 
+let net_name = ""; // network name prefix for the header, blank for mainnet.
+if (typeof MC_NETWORK !== 'undefined') {  // env variable set in webpack.<net>.js.
+  if (MC_NETWORK == 'testnet') {
+    net_name = 'TestNet'
+  }
+}
+
 export const Header: FC = (): ReactElement => {
   return (
     <>
@@ -35,7 +42,7 @@ export const Header: FC = (): ReactElement => {
                 paddingLeft: 2,
               }}
             >
-              MobileCoin / Reserve Electronic Dollar (eUSD) Auditor
+              {net_name} MobileCoin / Reserve Electronic Dollar (eUSD) Auditor
             </Typography>
           </Toolbar>
         </Container>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -99,3 +99,120 @@ export type TAuditedTokenResponse = {
   aux_burn_contract_addr: string
   aux_burn_function_sig: number[]
 }
+
+export type SafeMultisigConfirmationResponse = {
+  readonly owner: string
+  readonly submissionDate: string
+  readonly transactionHash?: string
+  readonly confirmationType?: string
+  readonly signature: string
+  readonly signatureType?: string
+}
+
+export type SafeMultisigTransactionResponse = {
+  readonly safe: string
+  readonly to: string
+  readonly value: string
+  readonly data?: string
+  readonly operation: number
+  readonly gasToken: string
+  readonly safeTxGas: number
+  readonly baseGas: number
+  readonly gasPrice: string
+  readonly refundReceiver?: string
+  readonly nonce: number
+  readonly executionDate: string
+  readonly submissionDate: string
+  readonly modified: string
+  readonly blockNumber?: number
+  readonly transactionHash: string
+  readonly safeTxHash: string
+  readonly executor?: string
+  readonly isExecuted: boolean
+  readonly isSuccessful?: boolean
+  readonly ethGasPrice?: string
+  readonly gasUsed?: number
+  readonly fee?: number
+  readonly origin: string
+  readonly dataDecoded?: string
+  readonly confirmationsRequired: number
+  readonly confirmations?: SafeMultisigConfirmationResponse[]
+  readonly signatures?: string
+}
+
+export type TokenInfoResponse = {
+  readonly type?: string
+  readonly address: string
+  readonly name: string
+  readonly symbol: string
+  readonly decimals: number
+  readonly logoUri?: string
+}
+
+export type TransferResponse = {
+  readonly type?: string
+  readonly executionDate: string
+  readonly blockNumber: number
+  readonly transactionHash: string
+  readonly to: string
+  readonly value: string
+  readonly tokenId: string
+  readonly tokenAddress?: string
+  readonly from: string
+}
+
+export type TransferWithTokenInfoResponse = TransferResponse & {
+  readonly tokenInfo: TokenInfoResponse
+}
+
+export type SafeModuleTransaction = {
+  readonly created?: string
+  readonly executionDate: string
+  readonly blockNumber?: number
+  readonly isSuccessful?: boolean
+  readonly transactionHash?: string
+  readonly safe: string
+  readonly module: string
+  readonly to: string
+  readonly value: string
+  readonly data: string
+  readonly operation: number
+  readonly dataDecoded?: string
+}
+
+export type SafeModuleTransactionWithTransfersResponse =
+  SafeModuleTransaction & {
+    readonly txType?: 'MODULE_TRANSACTION'
+    readonly transfers: TransferWithTokenInfoResponse[]
+  }
+
+export type SafeMultisigTransactionWithTransfersResponse =
+  SafeMultisigTransactionResponse & {
+    readonly txType?: 'MULTISIG_TRANSACTION'
+    readonly transfers: TransferWithTokenInfoResponse[]
+  }
+
+export type EthereumTxResponse = {
+  readonly executionDate: string
+  readonly to: string
+  readonly data: string
+  readonly txHash: string
+  readonly blockNumber?: number
+  readonly from: string
+}
+
+export type EthereumTxWithTransfersResponse = EthereumTxResponse & {
+  readonly txType?: 'ETHEREUM_TRANSACTION'
+  readonly transfers: TransferWithTokenInfoResponse[]
+}
+
+export type TGnosisSafeAllTransactionsListResponse = {
+  readonly count: number
+  readonly next?: string
+  readonly previous?: string
+  readonly results: Array<
+    | SafeModuleTransactionWithTransfersResponse
+    | SafeMultisigTransactionWithTransfersResponse
+    | EthereumTxWithTransfersResponse
+  >
+}

--- a/frontend/webpack/webpack.testnet.js
+++ b/frontend/webpack/webpack.testnet.js
@@ -7,8 +7,9 @@ module.exports = {
     // new BundleAnalyzerPlugin(),
     new DefinePlugin({
       AUDITOR_URL: JSON.stringify('https://auditor.test.mobilecoin.com/api/'),
-      GNOSIS_SAFE_API_URL: JSON.stringify('https://safe-transaction.goerli.gnosis.io'),
+      GNOSIS_SAFE_API_URL: JSON.stringify('https://safe-transaction-goerli.safe.global'),
       ETHERSCAN_URL: JSON.stringify('https://goerli.etherscan.io'),
+      MC_NETWORK: JSON.stringify('testnet'),
     })
   ]
 }


### PR DESCRIPTION
This PR addresses some issues with the TestNet auditor deploy (and fixes an issue for MainNet as well that was common to both)

Fixes:
- TestNet's Goerli Safe and RSV contracts aren't meshing in a way that the getGnosisSafeBalance call works. An alternative is to manually sum up all of the transactions in the Safe, and that has been added as a fallback when the getGnosisSafeBalance call fails.
- The link to the Goerli Safe now uses the correct address prefix (gor: instead of eth:)
- When there are no wraps in the history, "None" is displayed instead of "Loading..."
- The wraps list no longer has "Loading..." always at the bottom when the page height is shorter than the scroll.
- Restored displaying "TestNet" as part of the testnet page header.

Enhancement:
- TestNet auditor now renders with a different background color