### PR TITLE
update mobilecoind to v4.0.2 to support block v3

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         versions: 
           - {mobilecoind: v4.0.2-test, prefix: testnet}
-          - {mobilecoind: v3.0.0, prefix: mainnet}
+          - {mobilecoind: v4.0.2, prefix: mainnet}
 
     name: Build
     runs-on: [self-hosted, Linux, large]


### PR DESCRIPTION
- update mobilecoind to v4.0.2