### PR TITLE
use frontend dockerfile to build frontend

### DIFF
--- a/.github/workflows/build-deploy-staging.yaml
+++ b/.github/workflows/build-deploy-staging.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Docker
       uses: mobilecoinofficial/gh-actions/docker@v0
       with:
-        dockerfile: Dockerfile
+        dockerfile: .internal-ci/docker/Dockerfile.frontend
         images: mobilecoin/reserve-auditor-frontend
         flavor: latest=true
         tags: |


### PR DESCRIPTION
Frontend uses a different dockerfile.  Build with that dockerfile.