### PR TITLE
remove fftf from config

### DIFF
--- a/.internal-ci/charts/reserve-auditor/mainnet-values.yaml
+++ b/.internal-ci/charts/reserve-auditor/mainnet-values.yaml
@@ -29,8 +29,8 @@ mobilecoind:
   - url: 'mc://ideasbeyondborders.mobilecoin.bdnodes.net:443/'
     txSource: 'https://bd-mobilecoin-ledger.s3.amazonaws.com/ideasbeyondborders.mobilecoin.bdnodes.net/'
 
-  - url: 'mc://thelongnowfoundation.mobilecoin.bdnodes.net:443/'
-    txSource: 'https://bd-mobilecoin-ledger.s3.amazonaws.com/ideasbeyondborders.mobilecoin.bdnodes.net/'
+  - url: 'mc://ignite.mobilecoin.bdnodes.net:443/'
+    txSource: 'https://bd-mobilecoin-ledger.s3.amazonaws.com/ignite.mobilecoin.bdnodes.net/'
 
   - url: 'mc://ams1-mc-node1.dreamhost.com:3223/'
     txSource: 'https://s3-eu-west-1.amazonaws.com/dh-mobilecoin-eu/ams1-mc-node1.dreamhost.com/'


### PR DESCRIPTION
I would say we're removing fightforthefuture, but it looks like we never updated it after the longnow stopped sponsoring a node.