### PR TITLE
handle spam deposits made to Safe

### DIFF
--- a/src/gnosis/api_data_types.rs
+++ b/src/gnosis/api_data_types.rs
@@ -110,7 +110,7 @@ pub struct MultiSigTransaction {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TokenInfo {
     /// Number of decimals in non-integer representation
-    pub decimals: u32,
+    pub decimals: Option<u32>,
 
     /// Address of the token contract
     pub address: String,
@@ -143,7 +143,7 @@ pub struct EthereumTransfer {
     pub token_info: Option<TokenInfo>,
 
     /// Value being transferred
-    pub value: EthTxValue,
+    pub value: Option<EthTxValue>,
 }
 
 /// Ethereum transaction

--- a/src/gnosis/error.rs
+++ b/src/gnosis/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
     /// Api result parse error: {0}
     ApiResultParse(String),
 
+    /// Unknown Token: {0}
+    UnknownToken(String),
+
     /// Other: {0}
     Other(String),
 }

--- a/src/gnosis/sync.rs
+++ b/src/gnosis/sync.rs
@@ -112,8 +112,7 @@ impl GnosisSync {
                                 // log but otherwise ignore unknown token transfers
                                 if let Error::Gnosis(GnosisError::UnknownToken(_)) = err {
                                     log::warn!(self.logger, "Unknown token deposited to Safe");
-                                }
-                                else {
+                                } else {
                                     return Err(err);
                                 }
                             }

--- a/src/gnosis/sync.rs
+++ b/src/gnosis/sync.rs
@@ -106,7 +106,18 @@ impl GnosisSync {
 
                 match tx.decode()? {
                     Transaction::Ethereum(eth_tx) => {
-                        self.process_eth_transaction(&conn, &eth_tx)?;
+                        match self.process_eth_transaction(&conn, &eth_tx) {
+                            Ok(_) => {}
+                            Err(err) => {
+                                // log but otherwise ignore unknown token transfers
+                                if let Error::Gnosis(GnosisError::UnknownToken(_)) = err {
+                                    log::warn!(self.logger, "Unknown token deposited to Safe");
+                                }
+                                else {
+                                    return Err(err);
+                                }
+                            }
+                        }
                     }
                     Transaction::MultiSig(multi_sig_tx) => {
                         self.process_multi_sig_transaction(&conn, &multi_sig_tx)?;
@@ -150,11 +161,11 @@ impl GnosisSync {
                         .iter()
                         .find(|token| token.eth_token_contract_addrs.contains(token_addr))
                         .ok_or_else(|| {
-                            GnosisError::ApiResultParse("Unknown transfer token address".into())
+                            GnosisError::UnknownToken("Unknown token transfer".into())
                         })?;
 
                     let truncated_transaction_value = truncate_value(
-                        transfer.value,
+                        transfer.value.unwrap(),
                         token_config.decimals,
                         self.audited_safe.token_decimals_max,
                     );
@@ -163,7 +174,7 @@ impl GnosisSync {
                         None,
                         transfer.tx_hash,
                         tx.execution_date,
-                        transfer.value,
+                        transfer.value.unwrap(),
                         tx.eth_block_number,
                         transfer.to.clone(),
                         token_addr.clone(),
@@ -384,7 +395,7 @@ impl GnosisSync {
         let token_transfer = &token_transfers[0];
 
         // The number hould be EthTxValue-parseable
-        let eth_tx_value = token_transfer.value;
+        let eth_tx_value = token_transfer.value.unwrap();
 
         // the recipient address of the transaction
         let to_addr = token_transfer.to.clone();


### PR DESCRIPTION
### Motivation

Ethereum wallets are often sent tokens without requesting them. This is a form of  ERC20 spam.

The eUSD bridge has received some such tokens.

### Changes in This PR

This PR makes the auditor gnosis safe sync more robust by:

 - allows the decimals specified in a transfer to be null, as this is legal and a transfer may come back from Safe API with null decimals
 - similarly, allows for the transfer value to be null
 - logs a warning for deposits to the Safe that are for an unknown ERC20 type but otherwise ignores the deposit. Previously, the auditor would panic on such deposits.
 
