### PR TITLE
Reserve auditor cleanup

### DIFF
--- a/.github/workflows/build-deploy-staging.yaml
+++ b/.github/workflows/build-deploy-staging.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Docker
       uses: mobilecoinofficial/gh-actions/docker@v0
       with:
-        dockerfile: Dockerfile
+        dockerfile: .internal-ci/docker/Dockerfile.api
         images: mobilecoin/reserve-auditor
         build_args: |
           MOBILECOIND_BASE_TAG=${{ matrix.versions.mobilecoind }}

--- a/.internal-ci/charts/reserve-auditor/templates/api-statefulset.yaml
+++ b/.internal-ci/charts/reserve-auditor/templates/api-statefulset.yaml
@@ -22,48 +22,18 @@ spec:
     spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
-      securityContext: {}
-      volumes:
-      - name: gnosis-config
-        configMap:
-          name: {{ include "reserve-auditor.fullname" . }}-gnosis
-      - name: supervisor-conf
-        projected:
-          sources:
-          - configMap:
-              name: {{ include "reserve-auditor.fullname" . }}-mobilecoind
-          - configMap:
-              name: {{ include "reserve-auditor.fullname" . }}-scanner
-      {{- if not .Values.persistence.enabled }}
-      - name: data
-        emptyDir: {}
-      {{- end }}
-      initContainers:
-      - name: setup-files
-        {{- with .Values.mobilecoind }}
-        image: "{{ .image.repository }}:{{ .image.tag | default $.Chart.AppVersion }}"
-        {{-  end }}
-        command:
-        - /bin/bash
-        - -ec
-        - |
-          mkdir -p /data/auditor/
-          touch /data/auditor/auditor.db
-        volumeMounts:
-        - name: data
-          mountPath: /data/
       containers:
       {{- with .Values.mobilecoind }}
       - name: mobilecoind-ledger-scanner
         securityContext: {}
         image: "{{ .image.repository }}:{{ .image.tag | default $.Chart.AppVersion }}"
         imagePullPolicy: Always
-        command:
-        - /usr/bin/supervisord
-        - -n
         ports:
         - name: mobilecoind-rpc
           containerPort: 3229
+        - name: http
+          containerPort: 8080
+          protocol: TCP
         livenessProbe:
           exec:
             command:
@@ -93,50 +63,24 @@ spec:
         resources:
           {{- toYaml .resources | nindent 12 }}
       {{- end }}
-      - name: http-server
-        command:
-        - /bin/bash
-        - -ec
-        - |
-          until test -f /data/auditor/auditor.db; do
-            sleep 3
-            echo 'waiting for auditor db'
-          done
-          /usr/local/bin/mc-reserve-auditor \
-            start-http-server \
-            --host 0.0.0.0 \
-            --reserve-auditor-db /data/auditor/auditor.db \
-            --gnosis-safe-config /config/gnosis/config.json
-        volumeMounts:
-        - name: gnosis-config
-          mountPath: /config/gnosis
-        - name: data
-          mountPath: /data/
-        securityContext: {}
-        {{- with .Values.mobilecoind }}
-        image: "{{ .image.repository }}:{{ .image.tag | default $.Chart.AppVersion }}"
-        {{- end }}
-        imagePullPolicy: Always
-        ports:
-        - name: http
-          containerPort: 8080
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: http
-          failureThreshold: 2
-          periodSeconds: 15
-          initialDelaySeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /
-            port: http
-          failureThreshold: 2
-          periodSeconds: 15
-          initialDelaySeconds: 30
-        resources:
-          {{- toYaml .Values.httpServer.resources | nindent 12 }}
+      securityContext: {}
+      volumes:
+      - name: gnosis-config
+        configMap:
+          name: {{ include "reserve-auditor.fullname" . }}-gnosis
+      - name: supervisor-conf
+        projected:
+          sources:
+          - configMap:
+              name: {{ include "reserve-auditor.fullname" . }}-mobilecoind
+          - configMap:
+              name: {{ include "reserve-auditor.fullname" . }}-scanner
+          - configMap:
+              name: {{ include "reserve-auditor.fullname" . }}-httpserver
+      {{- if not .Values.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:

--- a/.internal-ci/charts/reserve-auditor/templates/supervisord-httpserver-configmap.yaml
+++ b/.internal-ci/charts/reserve-auditor/templates/supervisord-httpserver-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "reserve-auditor.labels" . | nindent 4 }}
 data:
-  ledger_scanner.conf: |
+  httpserver.conf: |
     [program:httpserver]
     priority=50
 

--- a/.internal-ci/charts/reserve-auditor/templates/supervisord-httpserver-configmap.yaml
+++ b/.internal-ci/charts/reserve-auditor/templates/supervisord-httpserver-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "reserve-auditor.fullname" . }}-httpserver
+  labels:
+    {{- include "reserve-auditor.labels" . | nindent 4 }}
+data:
+  ledger_scanner.conf: |
+    [program:httpserver]
+    priority=50
+
+    command=/usr/local/bin/wrapper-httpserver.sh
+    stdout_logfile=/dev/stdout
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/stdout
+    stderr_logfile_maxbytes=0
+    autorestart=true

--- a/.internal-ci/charts/reserve-auditor/templates/supervisord-mobilecoind-configmap.yaml
+++ b/.internal-ci/charts/reserve-auditor/templates/supervisord-mobilecoind-configmap.yaml
@@ -22,9 +22,9 @@ data:
           {{ include "reserve-auditor.quorumItem" . }},
         {{- end -}}
         {{- include "reserve-auditor.quorumItem" (last .peers) }}]}'
-      --ledger-db /data/ledger/ledger.db
-      --watcher-db /data/watcher/watcher-db
-      --mobilecoind-db /data/mobilecoind/mobilecoind.db
+      --ledger-db /data/ledger
+      --watcher-db /data/watcher
+      --mobilecoind-db /data/mobilecoind
       --listen-uri {{ .listenURI }}
     {{- end }}
 

--- a/.internal-ci/charts/reserve-auditor/templates/supervisord-scanner-configmap.yaml
+++ b/.internal-ci/charts/reserve-auditor/templates/supervisord-scanner-configmap.yaml
@@ -10,10 +10,10 @@ data:
     priority=100
 
     command=/usr/local/bin/mc-reserve-auditor scan-ledger 
-    	--ledger-db /data/ledger
-    	--watcher-db /data/watcher
-    	--reserve-auditor-db /data/auditor/auditor.db
-    	--gnosis-safe-config /config/gnosis/config.json
+      --ledger-db /data/ledger
+      --watcher-db /data/watcher
+      --reserve-auditor-db /data/auditor/auditor.db
+      --gnosis-safe-config /config/gnosis/config.json
 
     stdout_logfile=/dev/stdout
     stdout_logfile_maxbytes=0

--- a/.internal-ci/charts/reserve-auditor/templates/supervisord-scanner-configmap.yaml
+++ b/.internal-ci/charts/reserve-auditor/templates/supervisord-scanner-configmap.yaml
@@ -10,8 +10,8 @@ data:
     priority=100
 
     command=/usr/local/bin/mc-reserve-auditor scan-ledger 
-    	--ledger-db /data/ledger/ledger.db 
-    	--watcher-db /data/watcher/watcher-db
+    	--ledger-db /data/ledger
+    	--watcher-db /data/watcher
     	--reserve-auditor-db /data/auditor/auditor.db
     	--gnosis-safe-config /config/gnosis/config.json
 

--- a/.internal-ci/docker/Dockerfile.api
+++ b/.internal-ci/docker/Dockerfile.api
@@ -26,4 +26,6 @@ COPY --from=builder /build/target/release/mc-reserve-auditor /usr/local/bin/mc-r
 COPY --from=builder /build/consensus-enclave.css /measurement/consensus-enclave.css
 COPY --from=mobilecoind /usr/bin/mobilecoind /usr/bin/mobilecoind
 
+COPY .internal-ci/docker/entrypoints/api.sh /usr/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-n"]

--- a/.internal-ci/docker/Dockerfile.api
+++ b/.internal-ci/docker/Dockerfile.api
@@ -26,6 +26,7 @@ COPY --from=builder /build/target/release/mc-reserve-auditor /usr/local/bin/mc-r
 COPY --from=builder /build/consensus-enclave.css /measurement/consensus-enclave.css
 COPY --from=mobilecoind /usr/bin/mobilecoind /usr/bin/mobilecoind
 
+COPY .internal-ci/docker/support/api/wrapper-httpserver.sh /usr/local/bin/wrapper-httpserver.sh
 COPY .internal-ci/docker/entrypoints/api.sh /usr/bin/entrypoint.sh
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-n"]

--- a/.internal-ci/docker/entrypoints/api.sh
+++ b/.internal-ci/docker/entrypoints/api.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+data="/data"
+
+# Check for Existing datafiles in the old locations, and move them to the more standard locations
+if [[ -f "${data}/ledger/ledger.db/data.mdb" ]]
+then
+    echo "Moving old ledger data.mdb file to proper location"
+    mkdir -p "${data}/ledger"
+    mv "${data}/ledger/ledger.db/data.mdb" "${data}/ledger/data.mdb"
+    rm -rf "${data}/ledger/ledger.db"
+fi
+
+if [[ -f "${data}/watcher/watcher-db/data.mdb" ]]
+then
+    echo "Moving old watcher data.mdb file to proper location"
+    mkdir -p "${data}/watcher"
+    mv "${data}/watcher/watcher-db/data.mdb" "${data}/watcher/data.mdb"
+    rm -rf "${data}/watcher/watcher-db"
+fi
+
+if [[ -f "${data}/mobilecoind/mobilecoind.db/data.mdb" ]]
+then
+    echo "Moving old mobilecoind data.mdb file to proper location"
+    mkdir -p "${data}/mobilecoind"
+    mv "${data}/mobilecoind/mobilecoind.db/data.mdb" "${data}/mobilecoind/data.mdb"
+    rm -rf "${data}/mobilecoind/mobilecoind.db"
+fi
+
+if [[ -n "${MC_LEDGER_DB_URL}" ]]
+then
+    echo "MC_LEDGER_DB_URL set, restoring ${data}/ledger/data.mdb from backup"
+    if [[ -f "${data}/ledger/data.mdb" ]]
+    then
+        echo "Found existing ledger database, skipping download"
+    else
+        echo "Downloading ledger data.mdb"
+        mkdir -p "${data}/tmp-ledger"
+        curl -L "${MC_LEDGER_DB_URL}" -o "${data}/tmp-ledger/data.mdb"
+        mkdir -p "${data}/ledger"
+        mv "${data}/tmp-ledger/data.mdb" "${data}/ledger/data.mdb"
+    fi
+fi
+
+if [[ -n "${MC_WATCHER_DB_URL}" ]]
+then
+    echo "MC_WATCHER_DB_URL set, restoring ${data}/watcher/data.mdb from backup"
+    if [[ -f "${data}/watcher/data.mdb" ]]
+    then
+        echo "Found existing watcher database, skipping download"
+    else
+        echo "Downloading watcher data.mdb"
+        mkdir -p "${data}/tmp-watcher"
+        curl -L "${MC_WATCHER_DB_URL}" -o "${data}/tmp-watcher/data.mdb"
+        mkdir -p "${data}/watcher"
+        mv "${data}/tmp-watcher/data.mdb" "${data}/watcher/data.mdb"
+    fi
+fi
+
+# Run with docker command - probably /usr/bin/supervisord
+exec "$@"

--- a/.internal-ci/docker/entrypoints/api.sh
+++ b/.internal-ci/docker/entrypoints/api.sh
@@ -59,5 +59,9 @@ then
     fi
 fi
 
+# Touch the auditor.db just to make sure it exists
+mkdir -p /data/auditor
+touch /data/auditor/auditor.db
+
 # Run with docker command - probably /usr/bin/supervisord
 exec "$@"

--- a/.internal-ci/docker/entrypoints/api.sh
+++ b/.internal-ci/docker/entrypoints/api.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 data="/data"
 
 # Check for Existing datafiles in the old locations, and move them to the more standard locations

--- a/.internal-ci/docker/support/api/wrapper-httpserver.sh
+++ b/.internal-ci/docker/support/api/wrapper-httpserver.sh
@@ -5,14 +5,14 @@
 
 # First wait for the file to be created (should be created before anything starts)
 while test ! -f /data/auditor/auditor.db
-do 
+do
     echo "Wating for scanner to create /data/auditor/auditor.db"
     sleep 2
 done
 
 # Now wait for it to be a non-empty file. SQLite DB will be non-empty once created.
 while test ! -s /data/auditor/auditor.db
-do 
+do
     echo "Waiting for scanner to create SQLite database in /data/auditor/auditor.db"
     sleep 2
 done

--- a/.internal-ci/docker/support/api/wrapper-httpserver.sh
+++ b/.internal-ci/docker/support/api/wrapper-httpserver.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Wrapper script to watch for when scanner creates the auditor.db and then start the
+# http server.
+
+# First wait for the file to be created (should be created before anything starts)
+while test ! -f /data/auditor/auditor.db
+do 
+    echo "Wating for scanner to create /data/auditor/auditor.db"
+    sleep 2
+done
+
+# Now wait for it to be a non-empty file. SQLite DB will be non-empty once created.
+while test ! -s /data/auditor/auditor.db
+do 
+    echo "Waiting for scanner to create SQLite database in /data/auditor/auditor.db"
+    sleep 2
+done
+
+# Now we can start the http-server
+/usr/local/bin/mc-reserve-auditor \
+    start-http-server \
+    --host 0.0.0.0 \
+    --reserve-auditor-db /data/auditor/auditor.db \
+    --gnosis-safe-config /config/gnosis/config.json


### PR DESCRIPTION
This first PR just gets things set for later PRs. It does the following:
* Adds an entrypoint script for the API/backend
  * Moves the oddly named mdb locations to our more "standard" locations and names
  * Adds support for downloading the ledger data and the watcher data from pre-generated sources
  * Moves auditor.db `touch` to the entrypoint of the backend, out of the init-container
* Add wrapper for httpserver and moves it to main container
  * Waits for auditor.db to exist (should always exist at this point)
  * Waits for the auditor.db to be non-empty
  * Starts http-server
* Add supervisor conf for starting the http-server
* Cleanup the order of the api `StatefulSet` so that things are more where you'd expect them.